### PR TITLE
Potential fix for code scanning alert no. 2: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "remark-gfm": "^4.0.1",
     "remark-toc": "^9.0.0",
     "swiper": "^11.2.5",
-    "vite": "^6.2.1"
+    "vite": "^6.2.1",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.10",

--- a/scripts/update-descriptions-with-llm.js
+++ b/scripts/update-descriptions-with-llm.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync, spawn } = require('child_process');
-
+const sanitizeHtml = require('sanitize-html');
 // Function to check if gh models is available
 function isGhModelsAvailable() {
     try {
@@ -23,11 +23,10 @@ async function generateLLMSummary(content, title) {
 
     try {
         // Clean the content for LLM processing
-        const cleanContent = content
+        const cleanContent = sanitizeHtml(content, { allowedTags: [], allowedAttributes: {} })
             .replace(/^---[\s\S]*?---/, '') // Remove frontmatter
             .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // Remove markdown links but keep text
             .replace(/!\[([^\]]*)\]\([^)]*\)/g, '') // Remove markdown images
-            .replace(/<[^>]*>/g, '') // Remove HTML tags
             .replace(/\s+/g, ' ') // Normalize whitespace
             .trim()
             .substring(0, 2000); // Limit content for API


### PR DESCRIPTION
Potential fix for [https://github.com/martinwoodward/martinwoodward.github.io/security/code-scanning/2](https://github.com/martinwoodward/martinwoodward.github.io/security/code-scanning/2)

The best way to fix this problem is to use a well-tested sanitization library such as `sanitize-html` to remove all HTML tags and dangerous content from the input before further processing. If using a library is not possible, a safer alternative is to repeatedly apply the regular expression replacement until no more matches are found, or to use a regular expression that matches single `<` and `>` characters and removes them. In this case, since we only have access to the code in this file, the most robust fix is to use `sanitize-html` to clean the content. This requires adding an import for `sanitize-html` and replacing the current `.replace(/<[^>]*>/g, '')` line with a call to `sanitizeHtml(content, { allowedTags: [], allowedAttributes: {} })`, which strips all HTML tags and attributes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
